### PR TITLE
Improvements and Fixes

### DIFF
--- a/src/icp_rust_boilerplate_backend/src/lib.rs
+++ b/src/icp_rust_boilerplate_backend/src/lib.rs
@@ -73,7 +73,7 @@ impl BoundedStorable for Tweet {
 }
 
 impl BoundedStorable for IsUsed {
-    const MAX_SIZE: u32 = 8; // Rust uses 0 and 1 byte to represent true and false
+    const MAX_SIZE: u32 = 8;
     const IS_FIXED_SIZE: bool = false;
 }
 impl BoundedStorable for UserPrincipal {


### PR DESCRIPTION
## Improvements and Fixes

1. There was an issue on your canister where only one username could be stored at a time. Furthermore, users interacting with the canister could call the set_username to change the username to the username of the tweets they want to update or delete even though they aren't the author of those tweets. This also leads to another issue where it would be hard to keep track of who owns which tweets. So, I've gone ahead and modified the USERNAME variable to be a map<Principal, String> that essentially takes the caller's principal as the key and stores the caller's username as the value whenever we call the set_username function.
2. I have also added a check in the  set_username function to prevent users from setting their username more than once as this could lead to issues where other users could take the old usernames and thus modify/delete tweets they do not own. Alternatively, you could modify the TWEET_STORAGE to take a username as its key instead of a number, loop through all tweets, and update the username field whenever the set_username function is called.